### PR TITLE
fix issue when it is not possible to use package with 'cache: false' opt...

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,11 @@ module.exports = function mongooseCache(mongoose, options, cb) {
      * Patch the mongoose exec method
      */
     proto._exec = proto.exec;
-    proto.exec = function (op, callback) {
+    proto.exec = function (operation, cb) {
+
+        var op = operation;
+        var callback = cb;
+
         if (typeof op === 'function') {
             callback = op;
             op = null;


### PR DESCRIPTION
When using `cache: false` option in initial `options` object, then it is freezed on each find query because actual contents of arguments in `proto.exec` function are replaced in the begin of the function:

```
if (typeof op === 'function') {
         callback = op;
         op = null;
}
```

So when it tries to use default mongoose behaviour, mongoose doesn't receive valid callback and freezes.
